### PR TITLE
CLIExitCode errors

### DIFF
--- a/blockless-cli/src/cli_clap.rs
+++ b/blockless-cli/src/cli_clap.rs
@@ -73,6 +73,12 @@ fn parse_module(module: &str) -> Result<BlocklessModule> {
     })
 }
 
+#[derive(Debug)]
+pub enum RuntimeType {
+    V86,
+    Wasm,
+}
+
 #[derive(Parser, Debug)]
 pub(crate) struct CliCommandOpts {
     #[clap(long = "v86", value_name = "V86", required = false, help = V86_HELP )]
@@ -124,8 +130,12 @@ impl CliCommandOpts {
     }
     
     #[inline(always)]
-    pub fn is_v86(&self) -> bool {
-        self.v86
+    pub fn runtime_type(&self) -> RuntimeType {
+        if self.v86 {
+            RuntimeType::V86
+        } else {
+            RuntimeType::Wasm
+        }
     }
 
     #[inline(always)]

--- a/blockless-cli/src/error.rs
+++ b/blockless-cli/src/error.rs
@@ -1,0 +1,113 @@
+use std::{fmt, process::ExitCode};
+
+#[derive(Debug)]
+pub enum CLIExitCode {
+    FlueUsedOut,
+    CallStackExhausted,
+    OutOfBoundsMemoryAccess,
+    MisalignedMemoryAccess,
+    UndefinedElement,
+    UninitializedElement,
+    IndirectCallTypeMismatch,
+    IntegerOverflow,
+    IntegerDivideByZero,
+    InvalidConversionToInteger,
+    UnreachableInstructionExecuted,
+    Interrupt,
+    DegenerateComponentAdapterCalled,
+    AppTimeout,
+    ConfigureError,
+    UnknownError(String),
+}
+
+impl fmt::Display for CLIExitCode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            CLIExitCode::FlueUsedOut => write!(f, "The flue used out"),
+            CLIExitCode::CallStackExhausted => write!(f, "Call stack exhausted"),
+            CLIExitCode::OutOfBoundsMemoryAccess => write!(f, "Out of bounds memory access"),
+            CLIExitCode::MisalignedMemoryAccess => write!(f, "Misaligned memory access"),
+            CLIExitCode::UndefinedElement => write!(f, "Undefined element: out of bounds table access"),
+            CLIExitCode::UninitializedElement => write!(f, "Uninitialized element"),
+            CLIExitCode::IndirectCallTypeMismatch => write!(f, "Indirect call type mismatch"),
+            CLIExitCode::IntegerOverflow => write!(f, "Integer overflow"),
+            CLIExitCode::IntegerDivideByZero => write!(f, "Integer divide by zero"),
+            CLIExitCode::InvalidConversionToInteger => write!(f, "Invalid conversion to integer"),
+            CLIExitCode::UnreachableInstructionExecuted => write!(f, "wasm 'unreachable' instruction executed"),
+            CLIExitCode::Interrupt => write!(f, "Interrupt"),
+            CLIExitCode::DegenerateComponentAdapterCalled => write!(f, "Degenerate component adapter called"),
+            CLIExitCode::AppTimeout => write!(f, "The app timeout"),
+            CLIExitCode::ConfigureError => write!(f, "The configure error"),
+            CLIExitCode::UnknownError(err_str) => write!(f, "Unknown error: {}", err_str),
+        }
+    }
+}
+
+// derived from README
+impl From<i32> for CLIExitCode {
+  fn from(exitcode: i32) -> Self {
+    match exitcode {
+      1 => CLIExitCode::FlueUsedOut,
+      2 => CLIExitCode::CallStackExhausted,
+      3 => CLIExitCode::OutOfBoundsMemoryAccess,
+      4 => CLIExitCode::MisalignedMemoryAccess,
+      5 => CLIExitCode::UndefinedElement,
+      6 => CLIExitCode::UninitializedElement,
+      7 => CLIExitCode::IndirectCallTypeMismatch,
+      8 => CLIExitCode::IntegerOverflow,
+      9 => CLIExitCode::IntegerDivideByZero,
+      10 => CLIExitCode::InvalidConversionToInteger,
+      11 => CLIExitCode::UnreachableInstructionExecuted,
+      12 => CLIExitCode::Interrupt,
+      13 => CLIExitCode::DegenerateComponentAdapterCalled,
+      // NOTE: where is 14?
+      15 => CLIExitCode::AppTimeout,
+      128 => CLIExitCode::ConfigureError,
+      _ => CLIExitCode::UnknownError(format!("exit code: {}", exitcode)),
+    }
+  }
+}
+
+impl From<u8> for CLIExitCode {
+  fn from(exitcode: u8) -> Self {
+    Into::<i32>::into(exitcode).into()
+  }
+}
+
+impl Into<u8> for CLIExitCode {
+  fn into(self) -> u8 {
+    match self {
+      CLIExitCode::FlueUsedOut => 1,
+      CLIExitCode::CallStackExhausted => 2,
+      CLIExitCode::OutOfBoundsMemoryAccess => 3,
+      CLIExitCode::MisalignedMemoryAccess => 4,
+      CLIExitCode::UndefinedElement => 5,
+      CLIExitCode::UninitializedElement => 6,
+      CLIExitCode::IndirectCallTypeMismatch => 7,
+      CLIExitCode::IntegerOverflow => 8,
+      CLIExitCode::IntegerDivideByZero => 9,
+      CLIExitCode::InvalidConversionToInteger => 10,
+      CLIExitCode::UnreachableInstructionExecuted => 11,
+      CLIExitCode::Interrupt => 12,
+      CLIExitCode::DegenerateComponentAdapterCalled => 13,
+      // NOTE: where is 14?
+      CLIExitCode::AppTimeout => 15,
+      CLIExitCode::ConfigureError => 128,
+      CLIExitCode::UnknownError(_) => 255,
+    }
+  }
+}
+
+impl Into<i32> for CLIExitCode {
+  fn into(self) -> i32 {
+    Into::<u8>::into(self) as i32
+  }
+}
+
+impl Into<ExitCode> for CLIExitCode {
+  fn into(self) -> ExitCode {
+    ExitCode::from(Into::<u8>::into(self))
+  }
+}
+
+impl std::error::Error for CLIExitCode {}


### PR DESCRIPTION
## Context
We should remove all `unwrap` from the code - to gracefully handle unwanted `panics` at runtime.
This is something we should strive for - especially to get code to a _production ready_ state.


## CLIExitCode
The idea here was to integrate the with the specified ExitCode table in the readme:

```
|code|description|
|----|-------------------|
|Exit Code 1|The flue used out|
|Exit Code 2|call stack exhausted|
|Exit Code 3|out of bounds memory access|
|Exit Code 4|misaligned memory access|
|Exit Code 5|undefined element: out of bounds table access|
|Exit Code 6|uninitialized element|
|Exit Code 7|indirect call type mismatch|
|Exit Code 8|integer overflow|
|Exit Code 9|integer divide by zero|
|Exit Code 10|invalid conversion to integer|
|Exit Code 11|wasm `unreachable` instruction executed|
|Exit Code 12|interrupt|
|Exit Code 13|degenerate component adapter called|
|Exit Code 15|the app timeout.|
|Exit Code 128|The configure error.|
```

The `CLIExitCode` is simple abstraction over the `ExitCode` - which can convert from/to specific exit codes and the `ExitCode` struct itself.
This way we won't need to know exactly what each exit code number implies.

---

Note: This PR only introduces the `CLIExitCode` struct and utilizes it in the `main.rs` file to replace all `unwrap` calls; future PRs would be responsible for introducing it throughout the codebase.