### PR TITLE
Validate runtime module reactor full support

### DIFF
--- a/blockless/src/lib.rs
+++ b/blockless/src/lib.rs
@@ -410,4 +410,72 @@ mod test {
         let code = run_blockless(config);
         assert_eq!(code.code, 0);
     }
+
+    #[test]
+    fn test_blockless_reactor_module_can_call_reactor_module() {
+        let primary_code = r#"
+        (module
+            (import "reactor1" "double1" (func $double1 (param i32) (result i32)))
+            (func (export "_start")
+                i32.const 2
+                call $double1
+                drop
+            )
+        )
+        "#;
+        let reactor_1_code = r#"
+        (module
+            (import "reactor2" "double2" (func $double2 (param i32) (result i32)))
+            (func (export "double1") (param i32) (result i32)
+                local.get 0
+                call $double2
+            )
+        )
+        "#;
+        let reactor_2_code = r#"
+        (module
+            (func $double2 (export "double2") (param i32) (result i32)
+                local.get 0
+                i32.const 2
+                i32.mul
+            )
+        )
+        "#;
+
+        let temp_dir = TempDir::new("blockless_run").unwrap();
+
+        let primary_path = temp_dir.path().join("run.wasm");
+        let reactor_1_path = temp_dir.path().join("reactor1.wasm");
+        let reactor_2_path = temp_dir.path().join("reactor2.wasm");
+        
+        fs::write(&primary_path, primary_code).unwrap();
+        fs::write(&reactor_1_path, reactor_1_code).unwrap();
+        fs::write(&reactor_2_path, reactor_2_code).unwrap();
+        
+        let modules = vec![
+            BlocklessModule { 
+                module_type: ModuleType::Entry, 
+                name: "".to_string(), 
+                file: primary_path.to_str().unwrap().to_string(), 
+                md5: format!("{:x}", md5::compute(primary_code)), 
+            },
+            BlocklessModule { 
+                module_type: ModuleType::Module, 
+                name: "reactor1".to_string(), 
+                file: reactor_1_path.to_str().unwrap().to_string(), 
+                md5: format!("{:x}", md5::compute(reactor_1_code)) 
+            },
+            BlocklessModule { 
+                module_type: ModuleType::Module, 
+                name: "reactor2".to_string(), 
+                file: reactor_2_path.to_str().unwrap().to_string(), 
+                md5: format!("{:x}", md5::compute(reactor_2_code)) 
+            },
+        ];
+        let mut config =  BlocklessConfig::new("_start");
+        config.set_version(BlocklessConfigVersion::Version1);
+        config.set_modules(modules);
+        let code = run_blockless(config);
+        assert_eq!(code.code, 0);
+    }
 }

--- a/blockless/src/lib.rs
+++ b/blockless/src/lib.rs
@@ -337,4 +337,77 @@ mod test {
         let code = run_blockless(config);
         assert_eq!(code.code, 0);
     }
+
+    #[test]
+    fn test_blockless_primary_module_can_call_multiple_reactor_modules() {
+        let primary_code = r#"
+        (module
+            (import "reactor1" "double1" (func $double1 (param i32) (result i32)))
+            (import "reactor2" "double2" (func $double2 (param i32) (result i32)))
+            (func (export "_start")
+                i32.const 2
+                call $double1
+                drop
+            
+                i32.const 4
+                call $double2
+                drop
+            )
+        )
+        "#;
+        let reactor_1_code = r#"
+        (module
+            (func (export "double1") (param i32) (result i32)
+                local.get 0
+                i32.const 2
+                i32.mul
+            )
+        )
+        "#;
+        let reactor_2_code = r#"
+        (module
+            (func (export "double2") (param i32) (result i32)
+                local.get 0
+                i32.const 2
+                i32.mul
+            )
+        )
+        "#;
+
+        let temp_dir = TempDir::new("blockless_run").unwrap();
+
+        let primary_path = temp_dir.path().join("run.wasm");
+        let reactor_1_path = temp_dir.path().join("reactor1.wasm");
+        let reactor_2_path = temp_dir.path().join("reactor2.wasm");
+        
+        fs::write(&primary_path, primary_code).unwrap();
+        fs::write(&reactor_1_path, reactor_1_code).unwrap();
+        fs::write(&reactor_2_path, reactor_2_code).unwrap();
+        
+        let modules = vec![
+            BlocklessModule { 
+                module_type: ModuleType::Entry, 
+                name: "".to_string(), 
+                file: primary_path.to_str().unwrap().to_string(), 
+                md5: format!("{:x}", md5::compute(primary_code)), 
+            },
+            BlocklessModule { 
+                module_type: ModuleType::Module, 
+                name: "reactor1".to_string(), 
+                file: reactor_1_path.to_str().unwrap().to_string(), 
+                md5: format!("{:x}", md5::compute(reactor_1_code)) 
+            },
+            BlocklessModule { 
+                module_type: ModuleType::Module, 
+                name: "reactor2".to_string(), 
+                file: reactor_2_path.to_str().unwrap().to_string(), 
+                md5: format!("{:x}", md5::compute(reactor_2_code)) 
+            },
+        ];
+        let mut config =  BlocklessConfig::new("_start");
+        config.set_version(BlocklessConfigVersion::Version1);
+        config.set_modules(modules);
+        let code = run_blockless(config);
+        assert_eq!(code.code, 0);
+    }
 }

--- a/blockless/src/lib.rs
+++ b/blockless/src/lib.rs
@@ -459,17 +459,18 @@ mod test {
                 file: primary_path.to_str().unwrap().to_string(), 
                 md5: format!("{:x}", md5::compute(primary_code)), 
             },
-            BlocklessModule { 
-                module_type: ModuleType::Module, 
-                name: "reactor1".to_string(), 
-                file: reactor_1_path.to_str().unwrap().to_string(), 
-                md5: format!("{:x}", md5::compute(reactor_1_code)) 
-            },
+            // ensure we load/link reactor2 before reactor1 since reactor1 depends on it
             BlocklessModule { 
                 module_type: ModuleType::Module, 
                 name: "reactor2".to_string(), 
                 file: reactor_2_path.to_str().unwrap().to_string(), 
                 md5: format!("{:x}", md5::compute(reactor_2_code)) 
+            },
+            BlocklessModule { 
+                module_type: ModuleType::Module, 
+                name: "reactor1".to_string(), 
+                file: reactor_1_path.to_str().unwrap().to_string(), 
+                md5: format!("{:x}", md5::compute(reactor_1_code)) 
             },
         ];
         let mut config =  BlocklessConfig::new("_start");
@@ -480,6 +481,7 @@ mod test {
     }
 
     #[test]
+    #[ignore = "cross imports not supported"]
     fn test_blockless_reactor_module_can_call_reactor_module_with_callback_support() {
         let primary_code = r#"
         (module
@@ -553,6 +555,7 @@ mod test {
     }
 
     #[test]
+    #[ignore = "cross imports and callback loops not supported"]
     fn test_blockless_reactor_module_can_call_reactor_module_with_callback_endless_loop() {
         let primary_code = r#"
         (module

--- a/blockless/src/lib.rs
+++ b/blockless/src/lib.rs
@@ -478,4 +478,77 @@ mod test {
         let code = run_blockless(config);
         assert_eq!(code.code, 0);
     }
+
+    #[test]
+    fn test_blockless_reactor_module_can_call_reactor_module_with_callback_support() {
+        let primary_code = r#"
+        (module
+            (import "reactor1" "double1" (func $double1 (param i32) (result i32)))
+            (func (export "_start")
+                i32.const 2
+                call $double1
+                drop
+            )
+        )
+        "#;
+        let reactor_1_code = r#"
+        (module
+            (import "reactor2" "double2" (func $double2 (param i32) (result i32)))
+            (func (export "double1") (param i32) (result i32)
+                local.get 0
+                call $double2
+            )
+            (func (export "double1callback") (param i32) (result i32)
+                local.get 0
+                i32.const 2
+                i32.mul
+            )
+        )
+        "#;
+        let reactor_2_code = r#"
+        (module
+            (import "reactor1" "double1callback" (func $double1callback (param i32) (result i32)))
+            (func (export "double2") (param i32) (result i32)
+                local.get 0
+                call $double1callback
+            )
+        )
+        "#;
+
+        let temp_dir = TempDir::new("blockless_run").unwrap();
+
+        let primary_path = temp_dir.path().join("run.wasm");
+        let reactor_1_path = temp_dir.path().join("reactor1.wasm");
+        let reactor_2_path = temp_dir.path().join("reactor2.wasm");
+        
+        fs::write(&primary_path, primary_code).unwrap();
+        fs::write(&reactor_1_path, reactor_1_code).unwrap();
+        fs::write(&reactor_2_path, reactor_2_code).unwrap();
+        
+        let modules = vec![
+            BlocklessModule { 
+                module_type: ModuleType::Entry, 
+                name: "".to_string(), 
+                file: primary_path.to_str().unwrap().to_string(), 
+                md5: format!("{:x}", md5::compute(primary_code)), 
+            },
+            BlocklessModule { 
+                module_type: ModuleType::Module, 
+                name: "reactor1".to_string(), 
+                file: reactor_1_path.to_str().unwrap().to_string(), 
+                md5: format!("{:x}", md5::compute(reactor_1_code)) 
+            },
+            BlocklessModule { 
+                module_type: ModuleType::Module, 
+                name: "reactor2".to_string(), 
+                file: reactor_2_path.to_str().unwrap().to_string(), 
+                md5: format!("{:x}", md5::compute(reactor_2_code)) 
+            },
+        ];
+        let mut config =  BlocklessConfig::new("_start");
+        config.set_version(BlocklessConfigVersion::Version1);
+        config.set_modules(modules);
+        let code = run_blockless(config);
+        assert_eq!(code.code, 0);
+    }
 }


### PR DESCRIPTION
## Context
https://linear.app/blockless/issue/ENG-938/runtime-reactor-module-support

This PR implements unit tests to validate runtime module functionality and behaviour of primary loaded module, the reactor modules and the interop between all these modules.

The following scenarios should be supported:
- [x] Verify primary module can call reactor module exported function
- [x] Verify primary module can call multiple reactor modules exported functions
- [x] Verify reactor module can call reactor module exported function
- [ ] Verify reactor module (1) can call reactor module (2) exported function - where reactor module (2) exported function calls back into another function in reactor module (1)
- [ ] Verify reactor module (1) can call reactor module (2) exported function - where reactor module (2) exported function calls back into same function in reactor module (1) (this would be an endless loop)
